### PR TITLE
remove certificate verification

### DIFF
--- a/3rdparty/splQivivoAPI.php
+++ b/3rdparty/splQivivoAPI.php
@@ -7,7 +7,7 @@ https://github.com/KiboOst/php-simpleQivivoAPI
 
 class splQivivoAPI {
 
-    public $_version = '0.16';
+    public $_version = '0.17';
 
     //USER FUNCTIONS======================================================
 
@@ -267,6 +267,7 @@ class splQivivoAPI {
             curl_setopt($this->_curlHdl, CURLOPT_CONNECTTIMEOUT, 5);
             curl_setopt($this->_curlHdl, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($this->_curlHdl, CURLOPT_FOLLOWLOCATION, true);
+            curl_setopt($this->_curlHdl, CURLOPT_SSL_VERIFYPEER, 0);
         }
 
         curl_setopt($this->_curlHdl, CURLOPT_URL, $url);


### PR DESCRIPTION
qivivo API certificate expired since 4 days and still no solution on Qivivo side. Gasp!