### PR TITLE
Update setTempSettings function to remove use of a deprecated endpoint

### DIFF
--- a/3rdparty/comapAPI.php
+++ b/3rdparty/comapAPI.php
@@ -586,7 +586,7 @@ class qivivoAPI {
 
         $post = json_encode($settingsAr);
         $url = $this->_urlRoot.'/thermal/housings/'.$this->_houses[$houseId]['id'].'/custom-temperatures';
-        $answer = $this->_request('PUT', $url, $post);
+        $answer = $this->_request('PATCH', $url, $post);
 
         if ($this->isJson($answer))
         {

--- a/core/class/qivivo.class.php
+++ b/core/class/qivivo.class.php
@@ -1835,12 +1835,10 @@ class qivivoCmd extends cmd {
                     "away"=>$tempValue,
                     "frost_protection"=>$eqLogic->getCmd(null, 'frost_protection_temperature')->execCmd(),
                     "night"=>$eqLogic->getCmd(null, 'night_temperature')->execCmd(),
-                    "connected"=>array(
-                                    "presence_1"=>$eqLogic->getCmd(null, 'presence_temperature_1')->execCmd(),
-                                    "presence_2"=>$eqLogic->getCmd(null, 'presence_temperature_2')->execCmd(),
-                                    "presence_3"=>$eqLogic->getCmd(null, 'presence_temperature_3')->execCmd(),
-                                    "presence_4"=>$eqLogic->getCmd(null, 'presence_temperature_4')->execCmd()
-                                )
+                    "presence_1"=>$eqLogic->getCmd(null, 'presence_temperature_1')->execCmd(),
+                    "presence_2"=>$eqLogic->getCmd(null, 'presence_temperature_2')->execCmd(),
+                    "presence_3"=>$eqLogic->getCmd(null, 'presence_temperature_3')->execCmd(),
+                    "presence_4"=>$eqLogic->getCmd(null, 'presence_temperature_4')->execCmd()
                 );
 
                 $result = $_fullQivivo->setTempSettings($settingsAr, $_houseId);
@@ -1873,12 +1871,10 @@ class qivivoCmd extends cmd {
                     "away"=>$eqLogic->getCmd(null, 'absence_temperature')->execCmd(),
                     "frost_protection"=>$tempValue,
                     "night"=>$eqLogic->getCmd(null, 'night_temperature')->execCmd(),
-                    "connected"=>array(
-                                    "presence_1"=>$eqLogic->getCmd(null, 'presence_temperature_1')->execCmd(),
-                                    "presence_2"=>$eqLogic->getCmd(null, 'presence_temperature_2')->execCmd(),
-                                    "presence_3"=>$eqLogic->getCmd(null, 'presence_temperature_3')->execCmd(),
-                                    "presence_4"=>$eqLogic->getCmd(null, 'presence_temperature_4')->execCmd()
-                                )
+                    "presence_1"=>$eqLogic->getCmd(null, 'presence_temperature_1')->execCmd(),
+                    "presence_2"=>$eqLogic->getCmd(null, 'presence_temperature_2')->execCmd(),
+                    "presence_3"=>$eqLogic->getCmd(null, 'presence_temperature_3')->execCmd(),
+                    "presence_4"=>$eqLogic->getCmd(null, 'presence_temperature_4')->execCmd()
                 );
 
                 $result = $_fullQivivo->setTempSettings($settingsAr, $_houseId);
@@ -1910,12 +1906,10 @@ class qivivoCmd extends cmd {
                     "away"=>$eqLogic->getCmd(null, 'absence_temperature')->execCmd(),
                     "frost_protection"=>$eqLogic->getCmd(null, 'frost_protection_temperature')->execCmd(),
                     "night"=>$tempValue,
-                    "connected"=>array(
-                                    "presence_1"=>$eqLogic->getCmd(null, 'presence_temperature_1')->execCmd(),
-                                    "presence_2"=>$eqLogic->getCmd(null, 'presence_temperature_2')->execCmd(),
-                                    "presence_3"=>$eqLogic->getCmd(null, 'presence_temperature_3')->execCmd(),
-                                    "presence_4"=>$eqLogic->getCmd(null, 'presence_temperature_4')->execCmd()
-                                )
+                    "presence_1"=>$eqLogic->getCmd(null, 'presence_temperature_1')->execCmd(),
+                    "presence_2"=>$eqLogic->getCmd(null, 'presence_temperature_2')->execCmd(),
+                    "presence_3"=>$eqLogic->getCmd(null, 'presence_temperature_3')->execCmd(),
+                    "presence_4"=>$eqLogic->getCmd(null, 'presence_temperature_4')->execCmd()
                 );
 
                 $result = $_fullQivivo->setTempSettings($settingsAr, $_houseId);
@@ -1948,12 +1942,10 @@ class qivivoCmd extends cmd {
                     "away"=>$eqLogic->getCmd(null, 'absence_temperature')->execCmd(),
                     "frost_protection"=>$eqLogic->getCmd(null, 'frost_protection_temperature')->execCmd(),
                     "night"=>$eqLogic->getCmd(null, 'night_temperature')->execCmd(),
-                    "connected"=>array(
-                                    "presence_1"=>$tempValue,
-                                    "presence_2"=>$eqLogic->getCmd(null, 'presence_temperature_2')->execCmd(),
-                                    "presence_3"=>$eqLogic->getCmd(null, 'presence_temperature_3')->execCmd(),
-                                    "presence_4"=>$eqLogic->getCmd(null, 'presence_temperature_4')->execCmd()
-                                )
+                    "presence_1"=>$tempValue,
+                    "presence_2"=>$eqLogic->getCmd(null, 'presence_temperature_2')->execCmd(),
+                    "presence_3"=>$eqLogic->getCmd(null, 'presence_temperature_3')->execCmd(),
+                    "presence_4"=>$eqLogic->getCmd(null, 'presence_temperature_4')->execCmd()
                 );
 
                 $result = $_fullQivivo->setTempSettings($settingsAr, $_houseId);
@@ -1986,12 +1978,10 @@ class qivivoCmd extends cmd {
                     "away"=>$eqLogic->getCmd(null, 'absence_temperature')->execCmd(),
                     "frost_protection"=>$eqLogic->getCmd(null, 'frost_protection_temperature')->execCmd(),
                     "night"=>$eqLogic->getCmd(null, 'night_temperature')->execCmd(),
-                    "connected"=>array(
-                                    "presence_1"=>$eqLogic->getCmd(null, 'presence_temperature_1')->execCmd(),
-                                    "presence_2"=>$tempValue,
-                                    "presence_3"=>$eqLogic->getCmd(null, 'presence_temperature_3')->execCmd(),
-                                    "presence_4"=>$eqLogic->getCmd(null, 'presence_temperature_4')->execCmd()
-                                )
+                    "presence_1"=>$eqLogic->getCmd(null, 'presence_temperature_1')->execCmd(),
+                    "presence_2"=>$tempValue,
+                    "presence_3"=>$eqLogic->getCmd(null, 'presence_temperature_3')->execCmd(),
+                    "presence_4"=>$eqLogic->getCmd(null, 'presence_temperature_4')->execCmd()
                 );
 
                 $result = $_fullQivivo->setTempSettings($settingsAr, $_houseId);
@@ -2023,12 +2013,10 @@ class qivivoCmd extends cmd {
                     "away"=>$eqLogic->getCmd(null, 'absence_temperature')->execCmd(),
                     "frost_protection"=>$eqLogic->getCmd(null, 'frost_protection_temperature')->execCmd(),
                     "night"=>$eqLogic->getCmd(null, 'night_temperature')->execCmd(),
-                    "connected"=>array(
-                                    "presence_1"=>$eqLogic->getCmd(null, 'presence_temperature_1')->execCmd(),
-                                    "presence_2"=>$eqLogic->getCmd(null, 'presence_temperature_2')->execCmd(),
-                                    "presence_3"=>$tempValue,
-                                    "presence_4"=>$eqLogic->getCmd(null, 'presence_temperature_4')->execCmd()
-                                )
+                    "presence_1"=>$eqLogic->getCmd(null, 'presence_temperature_1')->execCmd(),
+                    "presence_2"=>$eqLogic->getCmd(null, 'presence_temperature_2')->execCmd(),
+                    "presence_3"=>$tempValue,
+                    "presence_4"=>$eqLogic->getCmd(null, 'presence_temperature_4')->execCmd()
                 );
 
                 $result = $_fullQivivo->setTempSettings($settingsAr, $_houseId);
@@ -2061,12 +2049,10 @@ class qivivoCmd extends cmd {
                     "away"=>$eqLogic->getCmd(null, 'absence_temperature')->execCmd(),
                     "frost_protection"=>$eqLogic->getCmd(null, 'frost_protection_temperature')->execCmd(),
                     "night"=>$eqLogic->getCmd(null, 'night_temperature')->execCmd(),
-                    "connected"=>array(
-                                    "presence_1"=>$eqLogic->getCmd(null, 'presence_temperature_1')->execCmd(),
-                                    "presence_2"=>$eqLogic->getCmd(null, 'presence_temperature_2')->execCmd(),
-                                    "presence_3"=>$eqLogic->getCmd(null, 'presence_temperature_3')->execCmd(),
-                                    "presence_4"=>$tempValue
-                                )
+                    "presence_1"=>$eqLogic->getCmd(null, 'presence_temperature_1')->execCmd(),
+                    "presence_2"=>$eqLogic->getCmd(null, 'presence_temperature_2')->execCmd(),
+                    "presence_3"=>$eqLogic->getCmd(null, 'presence_temperature_3')->execCmd(),
+                    "presence_4"=>$tempValue
                 );
 
                 $result = $_fullQivivo->setTempSettings($settingsAr, $_houseId);


### PR DESCRIPTION
## What's in this PR ?

We recently updated our thermal APIs and we've seen people using the Jeedom plugin having problems with their custom_temperatures being erased. It seems this plugin is using undocumented APIs that are now deprecated.

I updated the code to use the new endpoint and the format it should be using.

## How to test?

There is no CI nor instructions on how to test so I'm not sure it would work out of the box, but I hope you might test this!

#### P.S  
I added you on Twitter so we might discuss future changes on our APIs ! I think you were in contact with Sebastien whom leaved during summer 2022.

Hoping it might help your/our users!