### PR TITLE
Update COMAP API authorization to use AccessToken instead of IdToken

### DIFF
--- a/3rdparty/comapAPI.php
+++ b/3rdparty/comapAPI.php
@@ -813,15 +813,15 @@ class qivivoAPI {
                 return false;
             }
 
-            //get idToken:
-            if (isset($json['AuthenticationResult']['IdToken']))
+            //get AccessToken:
+            if (isset($json['AuthenticationResult']['AccessToken']))
             {
-                $this->_token = $json['AuthenticationResult']['IdToken'];
+                $this->_token = $json['AuthenticationResult']['AccessToken'];
                 return true;
             }
             else
             {
-                $this->error = 'Cannot find IdToken.';
+                $this->error = 'Cannot find AccessToken.';
                 return false;
             }
         }


### PR DESCRIPTION
# What's in this PR ?
Hi, COMAP developper here!
We are planning some changes on external API authorization to enhance security and partitioning of our endpoints. Therefore, in the future, IdToken won't be accepted by our authorizer since it does not provide scopes that we now require in the authorization process.

I updated the authorization to get the AccessToken that is already provided in the process instead of the IdToken currently in use.
# What's in this PR ?
I didn't test the changes inside Jeedom unfortunately but I re-tested the authorization process to be sure that the access token is complete and accepted by our new authorizer.