### PR TITLE
Add UserAgent attribute in ComapSmartHome API calls

### DIFF
--- a/3rdparty/comapAPI.php
+++ b/3rdparty/comapAPI.php
@@ -709,7 +709,8 @@ class qivivoAPI {
                 'Origin: https://app.comapsmarthome.com',
                 'referer: https://app.comapsmarthome.com',
                 'Host: api.comapsmarthome.com',
-                'Authorization: Bearer '.$this->_token
+                'User-Agent: JeedomPlugin',
+                'Authorization: Bearer '.$this->_token,
             ];
             if ($method == 'POST')
             {
@@ -790,6 +791,7 @@ class qivivoAPI {
             'accept-encoding: gzip, deflate, br',
             'content-type: application/x-amz-json-1.1',
             'x-amz-target: AWSCognitoIdentityProviderService.InitiateAuth',
+            'User-Agent: JeedomPlugin',
         ];
         curl_setopt($this->_curlHdl, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($this->_curlHdl, CURLOPT_URL, $this->_urlAuth);

--- a/core/class/qivivo.class.php
+++ b/core/class/qivivo.class.php
@@ -40,7 +40,7 @@ class qivivo extends eqLogic {
         if (isset($_customQivivo->error))
         {
             $_apiError = $_customQivivo->error;
-            qivivo::logger('custom Qivivo API error: '.$_apiError, 'warning');
+            qivivo::logger('custom ComapSmartHome API error: '.$_apiError, 'warning');
             if ($_typeCmd == 'action')
             {
                 if ($_msg)


### PR DESCRIPTION
Hi, COMAP developer here again!

We made a few security changes this morning on our APIs that broke Jeedom plugin (sorry for that :sweat_smile:). I did rollback the changes for the moment but we will enforce these security changes in the near future. 

It seems that the rule that blocked the calls was from a list of common security ruleset (rule #NoUserAgent_HEADER) so I made the changes in the comapAPI file (also not tested, sorry). I'm not completely sure if the requests you are currently performing will pass all the new security rules. We have a development environment completely decoupled from the production one where we are deploying new changes to test before production release. If you want to use it to validate the requests before the next security changes, I can help you set it up.

On another note, I made a little change on the error message since we have some Jeedom plugin users that thinks that Qivivo API is still alive and used in the plugin. The Qivivo name is not really used anymore, we changed it definitively to ComapSmartHome a few years ago when we developed the new platform and APIs so you might want to change references to this name, at least in the strings that users can really see to prevent further incomprehension.

Have a nice day!
